### PR TITLE
Revert "chore: update max python version"

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -35,7 +35,7 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = [
 license = "Apache 2.0"
 
 [tool.poetry.dependencies]
-python = "<3.13,>=3.7.1"
+python = "<3.11,>=3.7.1"
 requests = "^2.25.1"
 singer-sdk = { version="^0.14.0"}
 fs-s3fs = { version = "^1.1.1", optional = true}


### PR DESCRIPTION
Reverts MeltanoLabs/tap-duckdb#7

Tests failed

@riccelso  I assumed these were tested, we need to bump dependencies so it seems. 